### PR TITLE
Use default values for options when no specified in cli

### DIFF
--- a/example/commands/add.ts
+++ b/example/commands/add.ts
@@ -27,6 +27,7 @@ export class AddCommand implements Command<AddCommandParams> {
 
     const format = (val: number) => val.toLocaleString(undefined, {
       useGrouping: thousandSeparators,
+      minimumFractionDigits: decimalPlaces,
       maximumFractionDigits: decimalPlaces
     });
 

--- a/src/commander.test.ts
+++ b/src/commander.test.ts
@@ -142,7 +142,7 @@ describe('src/commander', () => {
       });
       expect(action).toBeDefined();
       await expect(action('john', undefined, {})).resolves.toBeUndefined();
-      expect(loginHandler).toHaveBeenCalledWith({ username: 'john' });
+      expect(loginHandler).toHaveBeenCalledWith({ username: 'john', rememberMeFor: 7 });
       // tslint:disable-next-line:no-console
       expect(console.error).toHaveBeenCalledWith(
         expect.stringMatching(/Computer says no/gi)

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -63,7 +63,10 @@ function getParams(
   const optionValues = args[paramIndex];
 
   for (const option of options) {
-    params[option.name.toString()] = optionValues[option.name];
+    const value = optionValues[option.name];
+    if (value !== undefined) {
+      params[option.name.toString()] = value;
+    }
   }
 
   return params;


### PR DESCRIPTION
Currently options are not being assign their default values if there are not specified within the cli as would be expected behaviour
